### PR TITLE
--quiet option to suppress unnecessary output

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,8 @@ Changelog
 0.1a4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add -q/--quiet option to suppress output which isn't strictly necessary
+  [Sasha Hart]
 
 
 0.1a3 (2012-11-30)

--- a/mrbob/cli.py
+++ b/mrbob/cli.py
@@ -47,7 +47,7 @@ parser.add_argument('-l', '--list-questions',
 parser.add_argument('-r', '--renderer',
                     action="store",
                     help='Dotted notation to a renderer function. Defaults to mrbob.rendering:jinja2_renderer')
-parser.add_argument('--quiet',
+parser.add_argument('-q', '--quiet',
                     action="store_true",
                     default=False,
                     help='Suppress all but necessary output')


### PR DESCRIPTION
Option to be less chatty. Questions themselves are still output as necessary. Error output is unchanged. Output from modules other than cli.py unchanged (so far).
