### PR TITLE
Fix order of string interpolation

### DIFF
--- a/mrbob/configurator.py
+++ b/mrbob/configurator.py
@@ -47,7 +47,7 @@ def resolve_dotted_func(name):
     if func:
         return func
     else:
-        raise ConfigurationError("There is no object named %s in module %s" % (module_name, func_name))
+        raise ConfigurationError("There is no object named %s in module %s" % (func_name, module_name))
 
 
 def maybe_resolve_dotted_func(name):


### PR DESCRIPTION
e.g. "There is no object named bobtemplates.kotti.hooks in module fanstatic_post_render" should be "There is no object named fanstatic_post_render in module bobtemplates.kotti.hooks" instead.
