### PR TITLE
Fix a broken link

### DIFF
--- a/docs/source/userguide.rst
+++ b/docs/source/userguide.rst
@@ -217,7 +217,7 @@ Collection of community managed templates
 -----------------------------------------
 
 You are encouraged to use the `bobtemplates.something` Python egg namespace to write
-templates and contribute them to this list by making a `pull request <github.com/iElectric/mr.bob>`_.
+templates and contribute them to this list by making a `pull request <https://github.com/iElectric/mr.bob>`_.
 
 - `bobtemplates.ielectric <https://github.com/iElectric/bobtemplates.ielectric>`_
 - `bobtemplates.kotti <https://github.com/Kotti/bobtemplates.kotti>`_


### PR DESCRIPTION
On rtd the link point to http://mrbob.readthedocs.org/en/latest/github.com/iElectric/mr.bob
