### PR TITLE
provides a flexible orderable plugins render_filename with entrypoints

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,9 @@ Changelog
 0.1a10 (unreleased)
 -------------------
 
+- add entry_points plugins support for render_filename
+  [Jean-Philippe Camguilhem]
+
 - move exceptions to bobexceptions
   [Jean-Philippe Camguilhem]
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -54,3 +54,9 @@ Source documentation
 
 .. automodule:: mrbob.hooks
    :members:
+
+:mod:`mrbob.plugins` -- Included plugins
+-----------------------------------------
+
+.. automodule:: mrbob.plugins
+   :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -47,6 +47,7 @@ Welcome to mr.bob's documentation!
 
    userguide.rst
    templateauthor.rst
+   pluginauthor.rst
    other.rst
    developer.rst
    api.rst

--- a/docs/source/pluginauthor.rst
+++ b/docs/source/pluginauthor.rst
@@ -1,0 +1,81 @@
+
+.. _`writing your plugin`:
+
+Writing your own plugin
+=========================
+
+
+render_filename plugin
+-----------------------
+
+With your own plugin you can extend or override ``render_filename`` in a very flexible way.
+
+structure
+**********
+
+A render_filename plugin class must have an **order** attribute (optional but fully recommended) and a **get_filename** method.
+
+.. warning:: If it doesn't provide this method an ErrorAttribute is raised.
+
+`get_filename` must return a tuple where the first element is the rended new filename, and the second a boolean 
+
+
+
+plugin sample
+
+.. code-block:: python
+  
+ class NoBarInFilename():
+    order = 15
+
+    def __init__(self, filename, variables, will_continue=True):
+        self.filename = filename
+        self.variables = variables
+        self.will_continue = will_continue
+
+    def get_filename(self):
+        if 'bar' in self.filename:
+            self.filename = None
+        else:
+            self.filename = 'fake_foo_' + self.filename
+        
+        return self.filename, self.will_continue
+ 
+code behavior
+
+.. literalinclude:: ../../mrbob/rendering.py
+   :lines: 133-143
+
+
+If filename is None or the boolean is False,  filename is immediatly returned, otherwise new filename will be interpreted  over the mrbob render_filename function.
+
+
+Register your plugin(s) 
+************************
+
+You register your plugin(s) to mrbob with classic setuptools entrypoints within your setup.py egg file.
+
+    .. code-block:: python
+
+        entry_points='''
+        # -*- Entry points: -*-
+        [mr.bob.plugins]
+        render_filename=bobplugins.pkg.module:NoFooInFilename
+        render_filename=bobplugins.pkg.module:NoBarInFilename
+        render_filename=bobplugins.pkg.module:NeitherBarOrFooInFilename
+
+        ''',
+
+Here we have 3 render_filename plugins, assume that :
+
+ + NoFooInFilename  `order` attribute is 10
+ + NoBarInFilename  `order` attribute is 15
+ + NeitherBarOrFooInFilename  `order` attribute is 20
+
+If you don't specify a  `-r, --rdr-fname-plugin-target`  NeitherBarOrFooInFilename will be loaded due to its order attribute, higher is prefered.
+
+If you want to load NoBarInFilename, just invoque mr bob with -r 15 . If you target a non registered `order` an ErrorAttribute is raised ::
+ 
+ AttributeError: No plugin target 18 ! Registered are [10, 15, 20]
+
+If you register 2 max order plugins, an alphabetical asc sort based on namespace-pkg-classname will return the last

--- a/docs/source/userguide.rst
+++ b/docs/source/userguide.rst
@@ -48,6 +48,8 @@ Once you install mr.bob, the ``mrbob`` command is available::
                             Don't prompt for input. Fail if questions are required
                             but not answered
       -q, --quiet           Suppress all but necessary output
+      -r RDR_FNAME_PLUGIN_TARGET, --rdr-fname-plugin-target RDR_FNAME_PLUGIN_TARGET
+                            Specify target plugin like 10|20
 
 By default, the target directory is the current folder. The most basic use case is rendering a template from a relative folder::
 
@@ -224,3 +226,12 @@ templates and contribute them to this list by making a `pull request <https://gi
 - `bobtemplates.ielectric <https://github.com/iElectric/bobtemplates.ielectric>`_
 - `bobtemplates.kotti <https://github.com/Kotti/bobtemplates.kotti>`_
 - `bobtemplates.niteoweb <https://github.com/niteoweb/bobtemplates.niteoweb>`_
+
+
+Collection of community plugins
+-------------------------------
+
+You are encouraged to use the ``bobplugins.something`` Python egg namespace to write
+templates and contribute them to this list by making a `pull request <https://github.com/iElectric/mr.bob>`_.
+
+- `bobplugins.jpcw <https://github.com/jpcw/bobplugins.jpcw>`_

--- a/mrbob/cli.py
+++ b/mrbob/cli.py
@@ -64,6 +64,11 @@ parser.add_argument('-q', '--quiet',
                   #dest='overwrite',
                   #action='store_true',
                   #help='Always overwrite')
+parser.add_argument('-r', '--rdr-fname-plugin-target',
+                    type=int,
+                    default=None,
+                    dest='rdr_fname_plugin_target',
+                    help='Specify target plugin like 10|20')
 
 
 def main(args=sys.argv[1:]):
@@ -114,6 +119,7 @@ def main(args=sys.argv[1:]):
         'quiet': options.quiet,
         'remember_answers': options.remember_answers,
         'non_interactive': options.non_interactive,
+        'rdr_fname_plugin_target': options.rdr_fname_plugin_target,
     }
 
     bobconfig = update_config(update_config(global_bobconfig, file_bobconfig), cli_bobconfig)

--- a/mrbob/configurator.py
+++ b/mrbob/configurator.py
@@ -16,6 +16,7 @@ readline  # make pyflakes happy, readline makes interactive mode keep history
 import six
 from importlib import import_module
 
+import mrbob.plugins as plugins
 from .rendering import render_structure
 from .parsing import (
     parse_config,
@@ -113,8 +114,8 @@ class Configurator(object):
     - :attr:`template_dir` is root directory of the template
     - :attr:`is_tempdir` if template directory is temporary (when using zipfile)
     - :attr:`templateconfig` dictionary parsed from `template` section
-    - :attr:`questions` ordered list of `Question instances to be asked
-    - :attr:`bobconfig` dictionary parsed from `mrbob` section of the config
+    - :attr:`questions` ordered list of `Question` instances to be asked
+    - :attr:`bobconfig` dictionary parsed from `mrbobx` section of the config
 
     """
 
@@ -133,6 +134,7 @@ class Configurator(object):
         self.variables = variables
         self.defaults = defaults
         self.target_directory = os.path.realpath(target_directory)
+        self.plugins_options = {}
 
         # figure out template directory
         self.template_dir, self.is_tempdir = parse_template(template)
@@ -165,6 +167,10 @@ class Configurator(object):
         self.quiet = maybe_bool(self.bobconfig.get('quiet', False))
         self.remember_answers = maybe_bool(self.bobconfig.get('remember_answers', False))
         self.ignored_files = self.bobconfig.get('ignored_files', '').split()
+        self.plugins_options['render_filename'] = self.bobconfig.get('rdr_fname_plugin_target', None)
+
+        # load plugins
+        plugins.PLUGINS = dict((key, plugins.load_plugin(key, target=value)) for key, value in self.plugins_options.items())
 
         # parse template settings
         self.templateconfig = self.config['template']
@@ -237,7 +243,7 @@ class Question(object):
     :param help: Optional help message
     :param pre_ask_question: Space limited functions in dotted notation to ask before the question is asked
     :param post_ask_question: Space limited functions in dotted notation to ask aster the question is asked
-    :param **extra: Any extra parameters stored for possible extending of `Question` functionality
+    :param \**extra: Any extra parameters stored for possible extending of `Question` functionality
 
     Any of above parameters can be accessed as an attribute of `Question` instance.
 

--- a/mrbob/plugins.py
+++ b/mrbob/plugins.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+"""Plugins loader.
+
+    You can register your own plugins with entry_points.
+
+    Code a class in your egg and register it within your setup.py file
+
+    .. code-block:: python
+
+        entry_points='''
+        # -*- Entry points: -*-
+        [mr.bob.plugins]
+        render_filename=bobplugins.pkg.module:FooRenderFilename
+        ''',
+
+   If there are multiples plugins with same name, you could push yours with
+   different **order** attributes.
+
+   If you don't specify an order target `-r, --rdr-fname-plugin-target` the
+   plugin with max **order** attribute is prefered,
+   otherwise alphabetic sort on namespace returns the last entry.
+
+   If you specify a bad plugin target an error is raised ::
+
+    AttributeError: No plugin target 15 ! Registered are [10, 20]
+
+
+   .. note:: Please notice that just mrbob.rendering.render_filename is
+    actually plugguable, but code infra is here.
+
+"""
+
+__docformat__ = 'restructuredtext en'
+
+import operator
+import pkg_resources
+
+PLUGINS = {}
+entries = [entry for entry in
+           pkg_resources.iter_entry_points(group='mr.bob.plugins')]
+
+
+def load_plugin(plugin, entries=entries, target=None):
+    """Load and sort possibles plugins from pkg."""
+
+    if entries:
+        plugins = [(ep, '%d-%s-%s' % (getattr(ep.load(False), 'order', 10),
+                                      ep.module_name, ep.name))
+                    for ep in entries if ep.name == plugin]
+        ordered_plugins = sorted(plugins, key=operator.itemgetter(1))
+        if target is not None:
+            targets = [ep for ep in ordered_plugins
+                                if ep[1].split('-')[0] == str(target)]
+            if targets:
+                return targets[-1][0].load(False)
+            else:
+                registered = [int(ep[1].split('-')[0]) for ep in ordered_plugins]
+                raise AttributeError('No plugin target %d ! Registered are %s' % (target,
+                                                                                  registered))
+
+        return ordered_plugins[-1][0].load(False)
+
+# vim:set et sts=4 ts=4 tw=80:

--- a/mrbob/tests/fake_plugins.py
+++ b/mrbob/tests/fake_plugins.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Doc here.
+"""
+
+__docformat__ = 'restructuredtext en'
+
+
+class FooRenderFilename():
+    order = 15
+
+    def __init__(self, filename, variables):
+        self.filename = filename
+        self.variables = variables
+
+    def get_filename(self):
+        return 'fake_foo_' + self.filename, True
+
+
+class BarRenderFilename():
+    order = 20
+
+    def __init__(self, filename, variables):
+        self.filename = filename
+        self.variables = variables
+
+    def get_filename(self):
+        return self.filename + '_fake_bar', False
+
+
+class BadRenderFilename():
+    """A bad plugin which has not get_filename method."""
+
+
+# vim:set et sts=4 ts=4 tw=80:

--- a/mrbob/tests/test_plugins.py
+++ b/mrbob/tests/test_plugins.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+
+import pkg_resources
+import unittest
+
+
+foo_src = 'render_filename=mrbob.tests.fake_plugins:FooRenderFilename'
+bar_src = 'render_filename=mrbob.tests.fake_plugins:BarRenderFilename'
+bad_src = 'render_filename=mrbob.tests.fake_plugins:BadRenderFilename'
+
+foo_ep = pkg_resources.EntryPoint.parse(foo_src)
+bar_ep = pkg_resources.EntryPoint.parse(bar_src)
+bad_ep = pkg_resources.EntryPoint.parse(bad_src)
+
+unordered_pkg_mock_entries = [bad_ep, bar_ep, foo_ep]
+will_continue_mock_ep = [foo_ep]
+bad_mock_ep = [bad_ep]
+
+
+class load_pluginsTest(unittest.TestCase):
+
+    def test_load_plugin_max_order_is_loaded(self):
+        import mrbob.plugins
+        ep = mrbob.plugins.load_plugin('render_filename',
+                                        unordered_pkg_mock_entries)
+        self.assertEqual(ep.order, 20)
+
+    def test_load_plugin_target_is_loaded(self):
+        import mrbob.plugins
+        ep = mrbob.plugins.load_plugin('render_filename',
+                                        unordered_pkg_mock_entries,
+                                        target=15)
+
+        self.assertEqual(ep.order, 15)
+
+    def test_error_load_plugin_bad_target(self):
+        import mrbob.plugins
+        self.assertRaises(AttributeError, mrbob.plugins.load_plugin,
+                          'render_filename', unordered_pkg_mock_entries,
+                          target=19)
+
+# vim:set et sts=4 ts=4 tw=80:

--- a/mrbob/tests/test_rendering.py
+++ b/mrbob/tests/test_rendering.py
@@ -15,6 +15,7 @@ class render_structureTest(unittest.TestCase):
 
     def setUp(self):
         import mrbob
+        mrbob.plugins.PLUGINS = {'render_filename': None}
         self.fs_tempdir = mkdtemp()
         self.fs_templates = os.path.abspath(
             os.path.join(os.path.dirname(mrbob.__file__),
@@ -51,7 +52,7 @@ class render_structureTest(unittest.TestCase):
                  access_control='10.0.1.0/16 allow'),
             renderer=python_formatting_renderer,
         )
-        self.assertTrue(os.path.exists('%s/%s' % (self.fs_tempdir, '/usr/local/etc')))
+        self.assertTrue(os.path.exists('%s/%s' % (self.fs_tempdir, 'usr/local/etc')))
 
     def test_skip_mrbobini_copying(self):
         self.call_FUT(
@@ -316,6 +317,10 @@ class render_templateTest(unittest.TestCase):
 
 class render_filenameTest(unittest.TestCase):
 
+    def setUp(self):
+        import mrbob
+        mrbob.plugins.PLUGINS = {'render_filename': None}
+
     def call_FUT(self, filename, variables):
         from ..rendering import render_filename
         return render_filename(filename, variables)
@@ -356,6 +361,35 @@ class render_filenameTest(unittest.TestCase):
 
     def test_missing_key(self):
         self.assertRaises(KeyError, self.call_FUT, 'foo+bar+blub', dict())
+
+    def test_plugin_rdr_filename_is_bad(self):
+        from .test_plugins import bad_mock_ep
+        import mrbob.plugins
+        ep = mrbob.plugins.load_plugin('render_filename',
+                                        bad_mock_ep)
+        mrbob.plugins.PLUGINS['render_filename'] = ep
+        self.assertRaises(AttributeError, self.call_FUT, '+/bla/+/+bar+',
+                          dict(bar='em0'))
+
+    def test_plugin_rdr_filename_will_continue(self):
+        from .test_plugins import will_continue_mock_ep
+        import mrbob.plugins
+        ep = mrbob.plugins.load_plugin('render_filename',
+                                        will_continue_mock_ep)
+        mrbob.plugins.PLUGINS['render_filename'] = ep
+        t = self.call_FUT('+/bla/+/+bar+',
+                          dict(bar='em0'))
+        self.assertEqual(t, 'fake_foo_+/bla/+/em0')
+
+    def test_plugin_rdr_filename_will_not_continue(self):
+        from .test_plugins import unordered_pkg_mock_entries
+        import mrbob.plugins
+        ep = mrbob.plugins.load_plugin('render_filename',
+                                        unordered_pkg_mock_entries)
+        mrbob.plugins.PLUGINS['render_filename'] = ep
+        t = self.call_FUT('+/bla/+/+bar+',
+                          dict(bar='em0'))
+        self.assertEqual(t, '+/bla/+/+bar+_fake_bar')
 
 
 class parse_variablesTest(unittest.TestCase):


### PR DESCRIPTION
Flexible orderable plugin system with entrypoints to extend or override render_filename. Multi-registration available, specific target callable with -r, --rdr-fname-plugin-target cli option.
Long version here : https://github.com/jpcw/mr.bob/blob/03aecc4d16c54fa0964544a978128223d7d7d345/docs/source/pluginauthor.rst
