### PR TITLE
Cleaned up white space display which was particularly bad in non-interactive mode

### DIFF
--- a/mrbob/cli.py
+++ b/mrbob/cli.py
@@ -122,7 +122,9 @@ def main(args=sys.argv[1:]):
 
     c = None
     if bobconfig['verbose']:
+        print('')
         print('Configuration provided:')
+        print('')
         print('[variables] from ~/.mrbob')
         for line in pretty_format_config(original_global_variables):
             print(line)
@@ -152,7 +154,6 @@ def main(args=sys.argv[1:]):
         print('[mr.bob] from command line interface')
         for line in pretty_format_config(cli_bobconfig):
             print(line)
-        print('\n')
 
     try:
         c = Configurator(template=options.template,
@@ -165,16 +166,24 @@ def main(args=sys.argv[1:]):
             return c.print_questions()
 
         if c.questions and not maybe_bool(bobconfig['quiet']):
-            print("Welcome to mr.bob interactive mode. Before we generate directory structure, some questions need to be answered.")
-            print("")
-            print("Answer with a question mark to display help.")
-            print("Values in square brackets at the end of the questions show the default value if there is no answer.")
-            print("\n")
+            if options.non_interactive:
+                print('')
+                print('Welcome to mr.bob non-interactive mode. Questions will be answered by default values or hooks.')
+                print('')
+            else:
+                print('')
+                print('Welcome to mr.bob interactive mode. Before we generate directory structure, some questions need to be answered.')
+                print('')
+                print('Answer with a question mark to display help.')
+                print('Values in square brackets at the end of the questions show the default value if there is no answer.')
+                print('\n')
             c.ask_questions()
-            print("")
+            if not options.non_interactive:
+                print('')
         c.render()
         if not maybe_bool(bobconfig['quiet']):
             print("Generated file structure at %s" % os.path.realpath(options.target_directory))
+            print('')
         return
     except TemplateConfigurationError as e:
         parser.error(six.u('TemplateConfigurationError: %s') % e.args[0])

--- a/mrbob/configurator.py
+++ b/mrbob/configurator.py
@@ -340,5 +340,6 @@ class Question(object):
             print('\nExiting...')
             sys.exit(0)
 
-        print('')
+        if not non_interactive:
+            print('')
         return correct_answer


### PR DESCRIPTION
Hello :smile: 

This pull request includes general clean-ups in relation to output display in the various modes of mr.bob.

**Example 1: Before**

```
(flaskage)fots@fotsies-ubprecise-01:~/webdev$ ./mrbob flaskage/
Welcome to mr.bob interactive mode. Before we generate directory structure, some questions need to be answered.

Answer with a question mark to display help.
Values in square brackets at the end of the questions show the default value if there is no answer.


--> What is your filesystem name of your application (python module naming)? [flaskage]:

--> What is the friendly name of your application (spaces allowed)? [Flaskage]:

--> Please provide a one sentence description of your application [A complete and carefully designed template for use with the Flask web framework]:

--> What is the source code website URL for your application? [https://github.com/fgimian/flaskage]:

--> What license type does your application use (MIT | BSD | Apache | Other)? [MIT]:

--> What year would you like attached to your application? [2014]:

--> Would you like comments with code examples to be added to your project? [yes]:

--> Will you be deploying this application on a server running Python 2.6? [no]:

--> Who is the author of the application? [Happy Man]:

--> What is the name of your organisation? [Happy Technology]:

--> What is the email address of the author? [happyman@happytech.com]:


Generated file structure at /home/fots/webdev
(flaskage)fots@fotsies-ubprecise-01:~/webdev$
```

**Example 1: After**

```
(flaskage)fots@fotsies-ubprecise-01:~/webdev$ ./mrbob flaskage/

Welcome to mr.bob interactive mode. Before we generate directory structure, some questions need to be answered.

Answer with a question mark to display help.
Values in square brackets at the end of the questions show the default value if there is no answer.


--> What is your filesystem name of your application (python module naming)? [flaskage]:

--> What is the friendly name of your application (spaces allowed)? [Flaskage]:

--> Please provide a one sentence description of your application [A complete and carefully designed template for use with the Flask web framework]:

--> What is the source code website URL for your application? [https://github.com/fgimian/flaskage]:

--> What license type does your application use (MIT | BSD | Apache | Other)? [MIT]:

--> What year would you like attached to your application? [2014]:

--> Would you like comments with code examples to be added to your project? [yes]:

--> Will you be deploying this application on a server running Python 2.6? [no]:

--> Who is the author of the application? [Happy Man]:

--> What is the name of your organisation? [Happy Technology]:

--> What is the email address of the author? [happyman@happytech.com]:


Generated file structure at /home/fots/webdev

(flaskage)fots@fotsies-ubprecise-01:~/webdev$
```

**Example 2: Before**

```
(flaskage)fots@fotsies-ubprecise-01:~/webdev$ ./mrbob -n flaskage/
Welcome to mr.bob interactive mode. Before we generate directory structure, some questions need to be answered.

Answer with a question mark to display help.
Values in square brackets at the end of the questions show the default value if there is no answer.














Generated file structure at /home/fots/webdev
(flaskage)fots@fotsies-ubprecise-01:~/webdev$
```

**Example 2: After**

```
(flaskage)fots@fotsies-ubprecise-01:~/webdev$ ./mrbob -n flaskage/

Welcome to mr.bob non-interactive mode. Questions will be answered by default values or hooks.

Generated file structure at /home/fots/webdev

(flaskage)fots@fotsies-ubprecise-01:~/webdev$
```

**Example 3: Before**

```
(flaskage)fots@fotsies-ubprecise-01:~/webdev$ ./mrbob -nv flaskage/
Configuration provided:
[variables] from ~/.mrbob
[variables] from --config file
[defaults] from ~/.mrbob
[defaults] from --config file
[mr.bob] from ~/.mrbob
[mr.bob] from --config file
[mr.bob] from command line interface
non_interactive = True
quiet = False
remember_answers = False
verbose = True


Welcome to mr.bob interactive mode. Before we generate directory structure, some questions need to be answered.

Answer with a question mark to display help.
Values in square brackets at the end of the questions show the default value if there is no answer.














Copying /home/fots/webdev/flaskage/bower.json to /home/fots/webdev/bower.json
Copying /home/fots/webdev/flaskage/manage.py to /home/fots/webdev/manage.py
Copying /home/fots/webdev/flaskage/.bowerrc to /home/fots/webdev/.bowerrc
Copying /home/fots/webdev/flaskage/config.py to /home/fots/webdev/config.py
Copying /home/fots/webdev/flaskage/application/__init__.py to /home/fots/webdev/application/__init__.py
Copying /home/fots/webdev/flaskage/application/models/__init__.py to /home/fots/webdev/application/models/__init__.py
Copying /home/fots/webdev/flaskage/application/templates/layout.html to /home/fots/webdev/application/templates/layout.html
Copying /home/fots/webdev/flaskage/application/templates/index.html to /home/fots/webdev/application/templates/index.html
Copying /home/fots/webdev/flaskage/application/templates/layout.jade to /home/fots/webdev/application/templates/layout.jade
Copying /home/fots/webdev/flaskage/application/templates/index.jade to /home/fots/webdev/application/templates/index.jade
Copying /home/fots/webdev/flaskage/application/assets/less/bootstrap-custom.less to /home/fots/webdev/application/assets/less/bootstrap-custom.less
Copying /home/fots/webdev/flaskage/application/assets/coffee/flaskage.coffee to /home/fots/webdev/application/assets/coffee/flaskage.coffee
Copying /home/fots/webdev/flaskage/application/static/img/flaskage.png to /home/fots/webdev/application/static/img/flaskage.png
Copying /home/fots/webdev/flaskage/application/views/home.py to /home/fots/webdev/application/views/home.py
Copying /home/fots/webdev/flaskage/application/views/__init__.py to /home/fots/webdev/application/views/__init__.py
Rendering /home/fots/webdev/flaskage/+application.name+/manage.py.bob to /home/fots/webdev/flaskage/manage.py
Rendering /home/fots/webdev/flaskage/+application.name+/LICENSE.bob to /home/fots/webdev/flaskage/LICENSE
Rendering /home/fots/webdev/flaskage/+application.name+/requirements.txt.bob to /home/fots/webdev/flaskage/requirements.txt
Copying /home/fots/webdev/flaskage/+application.name+/.bowerrc to /home/fots/webdev/flaskage/.bowerrc
Rendering /home/fots/webdev/flaskage/+application.name+/config.py.bob to /home/fots/webdev/flaskage/config.py
Rendering /home/fots/webdev/flaskage/+application.name+/bower.json.bob to /home/fots/webdev/flaskage/bower.json
Rendering /home/fots/webdev/flaskage/+application.name+/application/__init__.py.bob to /home/fots/webdev/flaskage/application/__init__.py
Rendering /home/fots/webdev/flaskage/+application.name+/application/models/__init__.py.bob to /home/fots/webdev/flaskage/application/models/__init__.py
Rendering /home/fots/webdev/flaskage/+application.name+/application/templates/layout.html.bob to /home/fots/webdev/flaskage/application/templates/layout.html
Rendering /home/fots/webdev/flaskage/+application.name+/application/templates/index.html.bob to /home/fots/webdev/flaskage/application/templates/index.html
Rendering /home/fots/webdev/flaskage/+application.name+/application/templates/layout.jade.bob to /home/fots/webdev/flaskage/application/templates/layout.jade
Rendering /home/fots/webdev/flaskage/+application.name+/application/templates/index.jade.bob to /home/fots/webdev/flaskage/application/templates/index.jade
Copying /home/fots/webdev/flaskage/+application.name+/application/assets/less/bootstrap-custom.less to /home/fots/webdev/flaskage/application/assets/less/bootstrap-custom.less
Copying /home/fots/webdev/flaskage/+application.name+/application/assets/coffee/+application.name+.coffee to /home/fots/webdev/flaskage/application/assets/coffee/flaskage.coffee
Copying /home/fots/webdev/flaskage/+application.name+/application/static/img/flaskage.png to /home/fots/webdev/flaskage/application/static/img/flaskage.png
Rendering /home/fots/webdev/flaskage/+application.name+/application/views/home.py.bob to /home/fots/webdev/flaskage/application/views/home.py
Rendering /home/fots/webdev/flaskage/+application.name+/application/views/__init__.py.bob to /home/fots/webdev/flaskage/application/views/__init__.py
Rendering /home/fots/webdev/flaskage/+application.name+/tests/__init__.py.bob to /home/fots/webdev/flaskage/tests/__init__.py
Rendering /home/fots/webdev/flaskage/+application.name+/tests/test_home.py.bob to /home/fots/webdev/flaskage/tests/test_home.py
Copying /home/fots/webdev/flaskage/+application.name+/migrations/env.py to /home/fots/webdev/flaskage/migrations/env.py
Copying /home/fots/webdev/flaskage/+application.name+/migrations/README to /home/fots/webdev/flaskage/migrations/README
Copying /home/fots/webdev/flaskage/+application.name+/migrations/alembic.ini to /home/fots/webdev/flaskage/migrations/alembic.ini
Copying /home/fots/webdev/flaskage/+application.name+/migrations/script.py.mako to /home/fots/webdev/flaskage/migrations/script.py.mako
Copying /home/fots/webdev/flaskage/tests/test_home.py to /home/fots/webdev/tests/test_home.py
Copying /home/fots/webdev/flaskage/tests/__init__.py to /home/fots/webdev/tests/__init__.py
Copying /home/fots/webdev/flaskage/migrations/env.py to /home/fots/webdev/migrations/env.py
Copying /home/fots/webdev/flaskage/migrations/README to /home/fots/webdev/migrations/README
Copying /home/fots/webdev/flaskage/migrations/alembic.ini to /home/fots/webdev/migrations/alembic.ini
Copying /home/fots/webdev/flaskage/migrations/script.py.mako to /home/fots/webdev/migrations/script.py.mako
Generated file structure at /home/fots/webdev
(flaskage)fots@fotsies-ubprecise-01:~/webdev$
```

**Example 3: After**

```
(flaskage)fots@fotsies-ubprecise-01:~/webdev$ ./mrbob -nv flaskage/

Configuration provided:

[variables] from ~/.mrbob
[variables] from --config file
[defaults] from ~/.mrbob
[defaults] from --config file
[mr.bob] from ~/.mrbob
[mr.bob] from --config file
[mr.bob] from command line interface
non_interactive = True
quiet = False
remember_answers = False
verbose = True

Welcome to mr.bob non-interactive mode. Questions will be answered by default values or hooks.

Copying /home/fots/webdev/flaskage/bower.json to /home/fots/webdev/bower.json
Copying /home/fots/webdev/flaskage/manage.py to /home/fots/webdev/manage.py
Copying /home/fots/webdev/flaskage/.bowerrc to /home/fots/webdev/.bowerrc
Copying /home/fots/webdev/flaskage/config.py to /home/fots/webdev/config.py
Copying /home/fots/webdev/flaskage/application/__init__.py to /home/fots/webdev/application/__init__.py
Copying /home/fots/webdev/flaskage/application/models/__init__.py to /home/fots/webdev/application/models/__init__.py
Copying /home/fots/webdev/flaskage/application/templates/layout.html to /home/fots/webdev/application/templates/layout.html
Copying /home/fots/webdev/flaskage/application/templates/index.html to /home/fots/webdev/application/templates/index.html
Copying /home/fots/webdev/flaskage/application/templates/layout.jade to /home/fots/webdev/application/templates/layout.jade
Copying /home/fots/webdev/flaskage/application/templates/index.jade to /home/fots/webdev/application/templates/index.jade
Copying /home/fots/webdev/flaskage/application/assets/less/bootstrap-custom.less to /home/fots/webdev/application/assets/less/bootstrap-custom.less
Copying /home/fots/webdev/flaskage/application/assets/coffee/flaskage.coffee to /home/fots/webdev/application/assets/coffee/flaskage.coffee
Copying /home/fots/webdev/flaskage/application/static/img/flaskage.png to /home/fots/webdev/application/static/img/flaskage.png
Copying /home/fots/webdev/flaskage/application/views/home.py to /home/fots/webdev/application/views/home.py
Copying /home/fots/webdev/flaskage/application/views/__init__.py to /home/fots/webdev/application/views/__init__.py
Rendering /home/fots/webdev/flaskage/+application.name+/manage.py.bob to /home/fots/webdev/flaskage/manage.py
Rendering /home/fots/webdev/flaskage/+application.name+/LICENSE.bob to /home/fots/webdev/flaskage/LICENSE
Rendering /home/fots/webdev/flaskage/+application.name+/requirements.txt.bob to /home/fots/webdev/flaskage/requirements.txt
Copying /home/fots/webdev/flaskage/+application.name+/.bowerrc to /home/fots/webdev/flaskage/.bowerrc
Rendering /home/fots/webdev/flaskage/+application.name+/config.py.bob to /home/fots/webdev/flaskage/config.py
Rendering /home/fots/webdev/flaskage/+application.name+/bower.json.bob to /home/fots/webdev/flaskage/bower.json
Rendering /home/fots/webdev/flaskage/+application.name+/application/__init__.py.bob to /home/fots/webdev/flaskage/application/__init__.py
Rendering /home/fots/webdev/flaskage/+application.name+/application/models/__init__.py.bob to /home/fots/webdev/flaskage/application/models/__init__.py
Rendering /home/fots/webdev/flaskage/+application.name+/application/templates/layout.html.bob to /home/fots/webdev/flaskage/application/templates/layout.html
Rendering /home/fots/webdev/flaskage/+application.name+/application/templates/index.html.bob to /home/fots/webdev/flaskage/application/templates/index.html
Rendering /home/fots/webdev/flaskage/+application.name+/application/templates/layout.jade.bob to /home/fots/webdev/flaskage/application/templates/layout.jade
Rendering /home/fots/webdev/flaskage/+application.name+/application/templates/index.jade.bob to /home/fots/webdev/flaskage/application/templates/index.jade
Copying /home/fots/webdev/flaskage/+application.name+/application/assets/less/bootstrap-custom.less to /home/fots/webdev/flaskage/application/assets/less/bootstrap-custom.less
Copying /home/fots/webdev/flaskage/+application.name+/application/assets/coffee/+application.name+.coffee to /home/fots/webdev/flaskage/application/assets/coffee/flaskage.coffee
Copying /home/fots/webdev/flaskage/+application.name+/application/static/img/flaskage.png to /home/fots/webdev/flaskage/application/static/img/flaskage.png
Rendering /home/fots/webdev/flaskage/+application.name+/application/views/home.py.bob to /home/fots/webdev/flaskage/application/views/home.py
Rendering /home/fots/webdev/flaskage/+application.name+/application/views/__init__.py.bob to /home/fots/webdev/flaskage/application/views/__init__.py
Rendering /home/fots/webdev/flaskage/+application.name+/tests/__init__.py.bob to /home/fots/webdev/flaskage/tests/__init__.py
Rendering /home/fots/webdev/flaskage/+application.name+/tests/test_home.py.bob to /home/fots/webdev/flaskage/tests/test_home.py
Copying /home/fots/webdev/flaskage/+application.name+/migrations/env.py to /home/fots/webdev/flaskage/migrations/env.py
Copying /home/fots/webdev/flaskage/+application.name+/migrations/README to /home/fots/webdev/flaskage/migrations/README
Copying /home/fots/webdev/flaskage/+application.name+/migrations/alembic.ini to /home/fots/webdev/flaskage/migrations/alembic.ini
Copying /home/fots/webdev/flaskage/+application.name+/migrations/script.py.mako to /home/fots/webdev/flaskage/migrations/script.py.mako
Copying /home/fots/webdev/flaskage/tests/test_home.py to /home/fots/webdev/tests/test_home.py
Copying /home/fots/webdev/flaskage/tests/__init__.py to /home/fots/webdev/tests/__init__.py
Copying /home/fots/webdev/flaskage/migrations/env.py to /home/fots/webdev/migrations/env.py
Copying /home/fots/webdev/flaskage/migrations/README to /home/fots/webdev/migrations/README
Copying /home/fots/webdev/flaskage/migrations/alembic.ini to /home/fots/webdev/migrations/alembic.ini
Copying /home/fots/webdev/flaskage/migrations/script.py.mako to /home/fots/webdev/migrations/script.py.mako
Generated file structure at /home/fots/webdev

(flaskage)fots@fotsies-ubprecise-01:~/webdev$
```

Cheers
Fotis
