### PR TITLE
Implemented new hooks to validate URLs set a value to the target directory and run pre and post shell scripts

### DIFF
--- a/mrbob/tests/templates/scripthere1/script_post.sh
+++ b/mrbob/tests/templates/scripthere1/script_post.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+touch post_${MRBOB_TESTVAR}_1.out

--- a/mrbob/tests/templates/scripthere1/script_pre.sh
+++ b/mrbob/tests/templates/scripthere1/script_pre.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+touch pre_${MRBOB_TESTVAR}_1.out

--- a/mrbob/tests/templates/scripthere2/script_post.sh
+++ b/mrbob/tests/templates/scripthere2/script_post.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+touch post_file_2.out

--- a/mrbob/tests/templates/scripthere2/script_pre.sh
+++ b/mrbob/tests/templates/scripthere2/script_pre.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+touch pre_file_2.out

--- a/mrbob/tests/test_configurator.py
+++ b/mrbob/tests/test_configurator.py
@@ -43,16 +43,20 @@ def dummy_question_hook_skipquestion(configurator, question):  # pragma: no cove
 
 class DummyConfigurator(object):
     def __init__(self,
-                 defaults=None,
-                 bobconfig=None,
-                 templateconfig=None,
-                 variables=None,
+                 defaults={},
+                 bobconfig={},
+                 templateconfig={},
+                 template_dir='',
+                 target_directory='',
+                 variables={},
                  quiet=False):
-        self.defaults = defaults or {}
-        self.bobconfig = bobconfig or {}
-        self.variables = variables or {}
+        self.defaults = defaults
+        self.bobconfig = bobconfig
+        self.templateconfig = templateconfig
+        self.template_dir = template_dir
+        self.target_directory = target_directory
+        self.variables = variables
         self.quiet = quiet
-        self.templateconfig = templateconfig or {}
 
 
 class resolve_dotted_pathTest(unittest.TestCase):


### PR DESCRIPTION
Hey again,

This pull requests introduces 4 new hooks!  These include the ability to run shell scripts before or after rendering with all mr.bob variables passed to scripts as environment variables.  You can imagine the possibilities with this sort of power :smile: 

The new hooks are as follows:
- **validate_url**: Checks that a given URL is valid (based on Django's validator)
- **set_target_dir_basename**: Sets the default of a question to the base directory of the target directory
- **run_pre_script**: Runs a script before rendering
- **run_post_script**: Runs a script after rendering

I would also love to add a **validate_email** hook based on Django's code, but that involves a considerable addition due to the complexity that email addresses can have.

As per my email, the only question I have regarding this commit is a little utility function known as **_run_script** which is used by both the pre and post script hooks.  I've prefixed the utility function with an underscore to indicate it's private, but I'm not sure if this is enough to keep it out of the documentation.

To help avoiding merge conflicts, I didn't update HISTORY.rst myself this time.  Please add the following if you are happy with the merge when ready...

```
- Added new post-question hook ``mrbob.hooks.validate_url``
  [Fotis Gimian]

- Added new pre-question hook ``mrbob.hooks.set_target_dir_basename``
  [Fotis Gimian]

- Added new pre-render hook ``mrbob.hooks.run_pre_script``
  [Fotis Gimian]

- Added new post-render hook ``mrbob.hooks.run_post_script``
  [Fotis Gimian]
```

Please let me know your thoughts

Cheers
Fotis
