### PR TITLE
Avoid errors when special caracter in default value

### DIFF
--- a/mrbob/configurator.py
+++ b/mrbob/configurator.py
@@ -4,6 +4,7 @@ import os
 import re
 import sys
 import readline
+import chardet
 try:  # pragma: no cover
     from urllib import urlretrieve  # NOQA
 except ImportError:  # pragma: no cover
@@ -300,6 +301,9 @@ class Question(object):
 
                 # prepare question
                 if self.default:
+                    if not isinstance(self.default, unicode):
+                        encoding = chardet.detect(self.default)['encoding']
+                        self.default = self.default.decode(encoding)
                     question = six.u("--> %s [%s]: ") % (self.question, self.default)
                 else:
                     question = six.u("--> %s: ") % self.question

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ from setuptools import find_packages
 install_requires = [
     'setuptools',
     'six>=1.2.0',  # 1.1.0 release doesn't have six.moves.input
+    'chardet>=2.3.0',
 ]
 
 if (3,) < sys.version_info < (3, 3):


### PR DESCRIPTION
Hello, I got an error with the bobtemplates:plone_addon because there is an accent in my Author's name (git name). This will avoid the error, even if the special caracters are not well rendered. This could be improved
