### PR TITLE
ask all questions to trigger post answer hooks

### DIFF
--- a/mrbob/configurator.py
+++ b/mrbob/configurator.py
@@ -227,8 +227,7 @@ class Configurator(object):
                 f(self)
         # TODO: if users want to manipulate questions order, this is curently not possible.
         for question in self.questions:
-            if question.name not in self.variables:
-                self.variables[question.name] = question.ask(self)
+            self.variables[question.name] = question.ask(self)
         if self.post_ask:
             for f in self.post_ask:
                 f(self)
@@ -320,6 +319,8 @@ class Question(object):
 
                 if answer:
                     correct_answer = answer
+                elif non_interactive and configurator.variables.get(self.name):
+                    correct_answer = configurator.variables[self.name]
                 # if we don't have an answer, take default
                 elif self.default is not None:
                     correct_answer = maybe_bool(self.default)


### PR DESCRIPTION
Hey, it's been quite a few cases where I have needed to generate from a template non-interactively with just some variables provided in the variables file. Unfortunately, I have some variable setting in a post answer hook fashion, and it seems the post hook is not called if variable is already set. Let me give a toy example case.

Consider `.mrbob.ini` file as:
```
[questions]
foo.question = What is foo
foo.required = True
foo.version.post_ask_question = hooks:post_answer_hook_after_some_question
```

and variables `variables.ini` file as:
```
[variables]
foo = UPPERCASE
```

with the hook function:
```python
def post_answer_hook_after_some_question(configurator, question, answer):
    configurator.variables['bar'] = answer.lower()
    return answer
```

It seems calling `mrbob -n -c variables.ini -O somedirectory template` would not execute the function `post_answer_hook_after_some_question` and consequently, `bar` variable would not be set and template rendering might fail.

I was able to hack in some change to just make it work for my use case, but was wondering if a better way to achieve this exist. Alternatively, maybe a cleaner way could be integrated into `mrbob` to support such a use case?

Thanks!